### PR TITLE
ci: force jest to exit on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             - ~/.cache/yarn
       - run:
           name: Run tests
-          command: yarn test:ci
+          command: yarn test:ci --detectOpenHandles --forceExit
       - store_test_results:
           path: test-results
       # The following two steps are done in Travis CI


### PR DESCRIPTION
Fix for Jest tests not exiting after successful completion on CircleCI.